### PR TITLE
Corrigido erro de sintaxe do php 8 onde o count estava recebendo um b…

### DIFF
--- a/src/LynX39/LaraPdfMerger/tcpdf/tcpdi_parser.php
+++ b/src/LynX39/LaraPdfMerger/tcpdf/tcpdi_parser.php
@@ -483,7 +483,7 @@ class tcpdi_parser {
             $v = $sarr[$key];
             if (($key == '/Type') AND ($v[0] == PDF_TYPE_TOKEN AND ($v[1] == 'XRef'))) {
                 $valid_crs = true;
-            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1] >= 2))) {
+            } elseif (($key == '/Index') AND ($v[0] == PDF_TYPE_ARRAY AND count($v[1]) >= 2 )) {
                 // first object number in the subsection
                 $index_first = intval($v[1][0][1]);
                 // number of entries in the subsection


### PR DESCRIPTION
 CLI-11062 - Corrigido erro de sintaxe do php 8 onde o count estava recebendo um boolean

- Foi visto em outras versões da biblioteca que o codigo estava diferente da versão que a nossa versão estava sendo assim alterei o codigo para a maneira correta
- O problema não acontecia antes pois antes do PHP 8 não tinha problema passar um bool para o count, lançava um warning mas não um erro, como o PHP 8 ficou mais rigido com a questão de tipagem das funções começou a quebrar essa logica ao atualizar a versão da liguagem. 
- CLI-11062